### PR TITLE
Fixed incorrect spelling of method call in Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ describe("something", () => {
                 password: "wonderland"
             }]
         });
-        mockApp = mock.initilizeApp({});
+        mockApp = mock.initializeApp({});
     });
 
     it("should do something with the mock", () => {


### PR DESCRIPTION
The method initializeApp was spelled incorrectly in the sample when compare to the published method name.