### PR TITLE
Firebase typing module should be exported correctly

### DIFF
--- a/source/firebase.ts
+++ b/source/firebase.ts
@@ -4,5 +4,6 @@
  * found in the LICENSE file at https://github.com/cartant/firebase-nightlight
  */
 
-import * as _firebase from "firebase";
-export type firebase = typeof _firebase;
+import * as firebase from "firebase";
+
+export { firebase };


### PR DESCRIPTION
After adding this node module, my typescript stopped compiling.
There were a number of these errors: 
node_modules/firebase-nightlight/dist/mock-types.d.ts(15,18): error TS2503: Cannot find namespace 'firebase'.

This was caused by the `import { firebase } from "./firebase";` line being lost in the d.ts files in the dist folder due to the export of the module definition for firebase as a type instead of a module.

This commit will fix this issue.