### PR TITLE
Fix: Added firebase-interfaces to the dist:copy command

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "scripts": {
     "dist": "yarn run dist:build && yarn run dist:uglify && node scripts/banner.js",
     "dist:build": "yarn run dist:clean && yarn run dist:copy && tsc -p tsconfig-dist.json && browserify dist/index.js -s firebaseNightlight -o bundles/firebase-nightlight.umd.js",
-    "dist:copy": "cpy source/lodash.* dist/",
+    "dist:copy": "cpy source/lodash.* dist/ && cpy source/firebase-interfaces.* dist/",
     "dist:clean": "rimraf dist && rimraf bundles/firebase-nightlight.* && mkdirp bundles",
     "dist:uglify": "uglifyjs -c -m -o bundles/firebase-nightlight.min.umd.js bundles/firebase-nightlight.umd.js",
     "lint": "tslint --project tsconfig.json source/**/*.ts",


### PR DESCRIPTION
Hey, first of all thanks for creating this, I had started creating my own mocks and you saved me a ton of time.

While using Mock, Jest was complaining that it could not find the firebase definitions, investigating I noticed that the `firebase-interfaces` was missing from `dist`, since it will not be processed by the tsc compiler (it's a js file), I added it to the `dist:copy` script to include it in the builds like Lodash currently is.

Hope it can be reviewed, published soon!